### PR TITLE
fix: unnecessary memory allocation in literal matrix

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -145,7 +145,7 @@ impl Matrix {
             variables
         );
         let size = 2 * variables;
-        self.matrix = vec![vec![0; size]; size];
+        self.matrix = vec![Vec::new(); size];
     }
 }
 


### PR DESCRIPTION
I noticed this when I experienced OOM error in some test cases. This doesn't break correctness but causes program to use `n^2` memory instead of `n` where `n` is the number of variables.